### PR TITLE
Correct inaccurate root indicator (busyBox) check

### DIFF
--- a/android/app/src/main/java/money/terra/station/UtilLib/RootChecker.kt
+++ b/android/app/src/main/java/money/terra/station/UtilLib/RootChecker.kt
@@ -18,7 +18,7 @@ class RootChecker(reactContext: ReactApplicationContext?) : ReactContextBaseJava
     fun isDeviceRooted(promise: Promise) {
         try {
             RootBeer(context).let {
-                if (it.isRootedWithBusyBoxCheck) {
+                if (it.isRooted) {
                     promise.resolve(true)
                 }
             }


### PR DESCRIPTION
Assuming the intent of this code is to check if the device is rooted, the current code causes false positives. This update will remove the check for an indicator (BusyBox) that is known and documented (by the RootBeer author) to cause false positives. This update will not remove other checks used to indicate a rooted device.

This update changes the check from `rootBeer.isRootedWithBusyBoxCheck();` to `rootBeer.isRooted();`. 

This will allow OnePlus (and other) devices owners with non-rooted phones to run the app without getting a "The device is rooted."

Issue documented in more detail here: https://github.com/terra-money/station-mobile/issues/11

I am somewhat new to pull requests for projects of this nature, please be kind. 🙇 
