### PR TITLE
Fix contRact typo in UI label

### DIFF
--- a/src/screens/WalletConnectConfirm/MessageBox.tsx
+++ b/src/screens/WalletConnectConfirm/MessageBox.tsx
@@ -44,7 +44,7 @@ const MessageContents = ({ msg }: { msg: Msg }): ReactElement => {
           }}
         >
           <Text style={styles.executeContract} fontType="bold">
-            ExecuteContact
+            ExecuteContract
           </Text>
         </View>
         <TouchableOpacity


### PR DESCRIPTION
<img width="414" alt="PNG image 3" src="https://user-images.githubusercontent.com/34006/150084403-da1e0f95-3892-465f-9200-28d1e14eec68.png">

Just a typo I guess.