### PR TITLE
feat: support android popup mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,15 +29,21 @@
         android:usesCleartextTraffic="true"
 
         tools:replace="android:allowBackup">
+
+        <meta-data
+            android:name="android.allow_multiple_resumed_activities" android:value="true" />
+
         <activity
             android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+            android:configChanges="keyboard|keyboardHidden|orientation|smallestScreenSize|screenLayout|screenSize|uiMode"
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme"
             android:windowSoftInputMode="adjustPan|adjustResize"
-            android:exported="true">
+            android:resizeableActivity="true"
+            android:exported="true"
+            tools:targetApi="n">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Android N or higher supports popup mode.
But crash occurs when using station mobile's popup mode.

This commit adds manifest that support android popup mode.

![Screen_Recording_20220626-131716_Station mp4](https://user-images.githubusercontent.com/35752384/175799523-4038ffcf-07eb-4f31-96fb-d89334c9a2fa.gif)

