### PR TITLE
fix: webview reload when content is destroyed

### DIFF
--- a/src/App/WebViewContainer.tsx
+++ b/src/App/WebViewContainer.tsx
@@ -859,6 +859,9 @@ export const WebViewContainer = ({
         const req = nativeEvent.data && JSON.parse(nativeEvent.data)
         await WebViewListener(req)
       }}
+      onContentProcessDidTerminate={(): void =>
+        (webviewInstance?.current as unknown as WebView)?.reload()
+      }
       injectedJavaScript={`
         (function() {
           function wrap(fn) {


### PR DESCRIPTION
When webview content is destroyed, an empty screen is showed.
This fix reload content when WebView is destroyed.

https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455639-webviewwebcontentprocessdidtermi?language=objc