### PR TITLE
feat: ios app on mac

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,7 +14,8 @@ target 'TerraStation' do
   pod 'Permission-FaceID', :path => "#{permissions_path}/FaceID"
 
   pod 'TrezorCrypto'
-  pod 'IOSSecuritySuite'
+  #pod 'IOSSecuritySuite'
+  pod 'IOSSecuritySuite', :git => 'https://github.com/bokuhe/IOSSecuritySuite.git', :branch => 'feat/ios-app-on-mac'
 
   config = use_native_modules!
   use_react_native!(

--- a/ios/TerraStation/UtilLib/RootChecker.m
+++ b/ios/TerraStation/UtilLib/RootChecker.m
@@ -26,11 +26,9 @@ RCT_EXPORT_MODULE();
 
 - (NSArray *)pathsToCheck
 {
-  return @[
+  NSArray *paths = @[
     @"/Applications/Cydia.app",
     @"/Library/MobileSubstrate/MobileSubstrate.dylib",
-    @"/bin/bash",
-    @"/usr/sbin/sshd",
     @"/etc/apt",
     @"/private/var/lib/apt",
     @"/usr/sbin/frida-server",
@@ -49,19 +47,30 @@ RCT_EXPORT_MODULE();
     @"/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
     @"/System/Library/LaunchDaemons/com.ikey.bbot.plist",
     @"/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
-    @"/bin/sh",
-    @"/etc/ssh/sshd_config",
     @"/private/var/lib/cydia",
     @"/private/var/mobile/Library/SBSettings/Themes",
     @"/private/var/stash",
     @"/private/var/tmp/cydia.log",
-    @"/usr/bin/sshd",
-    @"/usr/libexec/sftp-server",
-    @"/usr/libexec/ssh-keysign",
     @"/var/cache/apt",
     @"/var/lib/apt",
     @"/var/lib/cydia",
   ];
+  
+  if (@available(iOS 14.0, *)) {
+    if([NSProcessInfo processInfo].isiOSAppOnMac == TRUE) {
+      return paths;
+    }
+  }
+  
+  return [paths arrayByAddingObjectsFromArray: @[
+    @"/bin/bash",
+    @"/usr/sbin/sshd",
+    @"/bin/sh",
+    @"/etc/ssh/sshd_config",
+    @"/usr/bin/sshd",
+    @"/usr/libexec/ssh-keysign",
+    @"/usr/libexec/sftp-server",
+  ]];
 }
 
 - (NSArray *)schemesToCheck
@@ -124,6 +133,7 @@ RCT_EXPORT_METHOD(isDeviceRooted:(RCTPromiseResolveBlock) resolve
 #if TARGET_OS_SIMULATOR
   return resolve(@NO);
 #endif
+  
   BOOL check = [self checkPaths] || [self checkSchemes] || [self canViolateSandbox] || [self checkIOSSecuritySuite];
   return resolve(check ? @YES : @NO);
 }


### PR DESCRIPTION
When running the station ios app on mac, an error saying rooted device is displayed and it is not executed. 

If running on mac, some checks are unnecessary.

This commit changed some check conditions when running on mac.

⚠️ Temporarily changed the pod's IOSSecuritySuite path. the version is updated, restore it.

⚠️ I haven't checked all features work on mac.

![스크린샷 2022-11-18 오후 1 50 09](https://user-images.githubusercontent.com/35752384/202620003-c5b0c06e-8280-48d7-9a4a-3a699307c67b.png)
